### PR TITLE
Add interfaces to generated OCPP 2.0.1 classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,57 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>add-request-interface</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <filesToInclude>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas/*Request.json</filesToInclude>
+                            <preserveDir>false</preserveDir>
+                            <outputDir>${project.build.directory}/generated-resources</outputDir>
+                            <replacements>
+                                <replacement>
+                                    <token>"definitions"</token>
+                                    <value>"javaInterfaces" : ["de.rwth.idsg.ocpp.jaxb.RequestType"],
+  "definitions"</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-response-interface</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <filesToInclude>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas/*Response.json</filesToInclude>
+                            <preserveDir>false</preserveDir>
+                            <outputDir>${project.build.directory}/generated-resources</outputDir>
+                            <replacements>
+                                <replacement>
+                                    <token>"definitions"</token>
+                                    <value>"javaInterfaces" : ["de.rwth.idsg.ocpp.jaxb.ResponseType"],
+  "definitions"</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
                 <version>1.1.1</version>
                 <configuration>
+                    <sourceDirectory>${project.build.directory}/generated-resources</sourceDirectory>
                     <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-                    <sourceDirectory>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas</sourceDirectory>
                     <targetPackage>ocpp._2020._03</targetPackage>
                     <includeJsr303Annotations>true</includeJsr303Annotations>
                     <useJodaDates>true</useJodaDates>
@@ -130,6 +175,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>process-resources</phase>
                         <goals>
                             <goal>generate</goal>
                         </goals>


### PR DESCRIPTION
The generated OCPP 2.0.1 classes did not implement any interface, preventing uniform handling of all requests or reponses.

Add an extra maven phase to generate modified JSON schemas with an extra property specifying either the existing RequestType or ResponseType Java interface that the generated class will implement.