### PR TITLE
implement "strictness modes" for bean validation

### DIFF
--- a/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanDeserializerModifierWithValidation.java
+++ b/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanDeserializerModifierWithValidation.java
@@ -16,13 +16,14 @@ import jakarta.validation.Validator;
 public class BeanDeserializerModifierWithValidation extends ValueDeserializerModifier {
 
     private final Validator validator;
+    private final StrictnessMode strictnessMode;
 
     @Override
     public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config,
                                                    Supplier beanDescRef,
                                                    ValueDeserializer<?> deserializer) {
         if (deserializer instanceof BeanDeserializerBase) {
-            return new BeanDeserializerWithValidation(deserializer, validator);
+            return new BeanDeserializerWithValidation(deserializer, validator, strictnessMode);
         }
 
         return deserializer;

--- a/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanDeserializerWithValidation.java
+++ b/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanDeserializerWithValidation.java
@@ -1,5 +1,6 @@
 package de.rwth.idsg.ocpp.jaxb.validation;
 
+import lombok.extern.slf4j.Slf4j;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
@@ -13,18 +14,22 @@ import jakarta.validation.Validator;
 /**
  * https://www.baeldung.com/java-object-validation-deserialization
  */
+@Slf4j
 public class BeanDeserializerWithValidation extends DelegatingDeserializer {
 
     private final Validator validator;
+    private final StrictnessMode strictnessMode;
 
-    protected BeanDeserializerWithValidation(ValueDeserializer<?> delegate, Validator validator) {
+    protected BeanDeserializerWithValidation(ValueDeserializer<?> delegate, Validator validator,
+                                             StrictnessMode strictnessMode) {
         super(delegate);
         this.validator = validator;
+        this.strictnessMode = strictnessMode;
     }
 
     @Override
     protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> newDelegate) {
-        return new BeanDeserializerWithValidation(newDelegate, validator);
+        return new BeanDeserializerWithValidation(newDelegate, validator, strictnessMode);
     }
 
     @Override
@@ -50,8 +55,14 @@ public class BeanDeserializerWithValidation extends DelegatingDeserializer {
 
     private <T> void validate(T object) {
         var violations = validator.validate(object);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
+        if (violations.isEmpty()) {
+            return;
+        }
+
+        var exception = new ConstraintViolationException(violations);
+        switch (strictnessMode) {
+            case LogWarning -> log.warn("There are constraint violations", exception);
+            case ThrowError -> throw exception;
         }
     }
 }

--- a/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanSerializerModifierWithValidation.java
+++ b/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanSerializerModifierWithValidation.java
@@ -13,13 +13,14 @@ import jakarta.validation.Validator;
 public class BeanSerializerModifierWithValidation extends ValueSerializerModifier {
 
     private final Validator validator;
+    private final StrictnessMode strictnessMode;
 
     @Override
     public ValueSerializer<?> modifySerializer(SerializationConfig config,
                                                BeanDescription.Supplier beanDesc,
                                                ValueSerializer<?> serializer) {
         if (serializer instanceof BeanSerializerBase) {
-            return new BeanSerializerWithValidation((BeanSerializerBase) serializer, validator);
+            return new BeanSerializerWithValidation((BeanSerializerBase) serializer, validator, strictnessMode);
         }
 
         return serializer;

--- a/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanSerializerWithValidation.java
+++ b/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanSerializerWithValidation.java
@@ -1,6 +1,7 @@
 package de.rwth.idsg.ocpp.jaxb.validation;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
@@ -10,20 +11,31 @@ import tools.jackson.databind.ser.bean.BeanSerializerBase;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 
+@Slf4j
 @RequiredArgsConstructor
 public class BeanSerializerWithValidation extends ValueSerializer<Object> {
 
     private final BeanSerializerBase delegate;
     private final Validator validator;
+    private final StrictnessMode strictnessMode;
 
     @Override
     public void serialize(Object bean, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
-        var violations = validator.validate(bean);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
+        validate(bean);
+        delegate.serialize(bean, gen, ctxt);
+    }
+
+    private <T> void validate(T object) {
+        var violations = validator.validate(object);
+        if (violations.isEmpty()) {
+            return;
         }
 
-        delegate.serialize(bean, gen, ctxt);
+        var exception = new ConstraintViolationException(violations);
+        switch (strictnessMode) {
+            case LogWarning -> log.warn("There are constraint violations", exception);
+            case ThrowError -> throw exception;
+        }
     }
 
 }

--- a/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanValidationModule.java
+++ b/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/BeanValidationModule.java
@@ -1,5 +1,6 @@
 package de.rwth.idsg.ocpp.jaxb.validation;
 
+import lombok.Builder;
 import tools.jackson.databind.module.SimpleModule;
 
 import jakarta.validation.Validation;
@@ -10,30 +11,47 @@ import jakarta.validation.Validator;
  */
 public class BeanValidationModule extends SimpleModule {
 
-    private BeanValidationModule(Validator validator, boolean forReading, boolean forWriting) {
+    @Builder
+    private BeanValidationModule(Validator validator, StrictnessMode readingMode, StrictnessMode writingMode) {
+        if (readingMode == null && writingMode == null) {
+            throw new NullPointerException("readingMode and writingMode are null");
+        }
+
         Validator validatorToUse = validator == null
             ? Validation.buildDefaultValidatorFactory().getValidator()
             : validator;
 
-        if (forReading) {
-            setDeserializerModifier(new BeanDeserializerModifierWithValidation(validatorToUse));
+        if (readingMode != null) {
+            setDeserializerModifier(new BeanDeserializerModifierWithValidation(validatorToUse, readingMode));
         }
 
-        if (forWriting) {
-            setSerializerModifier(new BeanSerializerModifierWithValidation(validatorToUse));
+        if (writingMode != null) {
+            setSerializerModifier(new BeanSerializerModifierWithValidation(validatorToUse, writingMode));
         }
     }
 
     public static BeanValidationModule forReading(Validator validator) {
-        return new BeanValidationModule(validator, true, false);
+        return BeanValidationModule.builder()
+            .validator(validator)
+            .readingMode(StrictnessMode.ThrowError)
+            .writingMode(null)
+            .build();
     }
 
     public static BeanValidationModule forWriting(Validator validator) {
-        return new BeanValidationModule(validator, false, true);
+        return BeanValidationModule.builder()
+            .validator(validator)
+            .readingMode(null)
+            .writingMode(StrictnessMode.ThrowError)
+            .build();
     }
 
     public static BeanValidationModule forReadingAndWriting(Validator validator) {
-        return new BeanValidationModule(validator, true, true);
+        return BeanValidationModule.builder()
+            .validator(validator)
+            .readingMode(StrictnessMode.ThrowError)
+            .writingMode(StrictnessMode.ThrowError)
+            .build();
     }
 
 }

--- a/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/StrictnessMode.java
+++ b/ocpp-jaxb/src/main/java/de/rwth/idsg/ocpp/jaxb/validation/StrictnessMode.java
@@ -1,0 +1,6 @@
+package de.rwth.idsg.ocpp.jaxb.validation;
+
+public enum StrictnessMode {
+    LogWarning,
+    ThrowError
+}

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Jackson 3.x components rely on 2.x annotations; there are no separate 3.x jackson-annotations -->
         <dependency>


### PR DESCRIPTION
motivation: throwing exception and interrupting operation may not always be desirable.