### PR TITLE
update dependency versions

### DIFF
--- a/ocpp-jaxb/pom.xml
+++ b/ocpp-jaxb/pom.xml
@@ -266,6 +266,11 @@
                 </executions>
                 <dependencies>
                     <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
+                    </dependency>
+                    <dependency>
                         <groupId>${project.groupId}</groupId>
                         <artifactId>ocpp-custom</artifactId>
                         <version>${project.version}</version>

--- a/ocpp-jaxb/pom.xml
+++ b/ocpp-jaxb/pom.xml
@@ -66,12 +66,12 @@
                     <dependency>
                         <groupId>org.jvnet.jaxb</groupId>
                         <artifactId>jaxb-plugins</artifactId>
-                        <version>4.0.8</version>
+                        <version>4.0.16</version>
                     </dependency>
                     <dependency>
                         <groupId>org.jvnet.jaxb</groupId>
                         <artifactId>jaxb-plugin-annotate</artifactId>
-                        <version>4.0.8</version>
+                        <version>4.0.16</version>
                     </dependency>
                     <!-- provides validation -->
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <cxf.version>4.0.5</cxf.version>
-        <lombok.version>1.18.34</lombok.version>
-        <jsonschema2pojo.version>1.2.1</jsonschema2pojo.version>
-        <jackson.version>3.0.3</jackson.version>
+        <lombok.version>1.18.46</lombok.version>
+        <jsonschema2pojo.version>1.3.3</jsonschema2pojo.version>
+        <jackson.version>3.2.1</jackson.version>
     </properties>
 
     <scm>
@@ -65,6 +65,13 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
@@ -141,7 +148,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
+            <version>2.22</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <cxf.version>4.0.5</cxf.version>
         <lombok.version>1.18.46</lombok.version>
         <jsonschema2pojo.version>1.3.3</jsonschema2pojo.version>
-        <jackson.version>3.2.1</jackson.version>
+        <jackson.version>3.2.2</jackson.version>
     </properties>
 
     <scm>
@@ -60,11 +60,11 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>
@@ -77,12 +77,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>@{project.version}</tagNameFormat>
@@ -136,6 +136,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -185,7 +186,7 @@
         <dependency>
             <groupId>tools.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>3.0.2</version>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
partially to address warnings such as:

> HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s).

these classes are generated.

- ✅  jsonschema2pojo 1.3.3 is already correct and generates `List<@Valid T>`.
- ❌ the other affected fields come from the JAXB/XJC-generated SOAP classes via krasa-jaxb-tools 2.5.1. there is no upstream release to fix them yet. an open issue exists at https://github.com/fillumina/krasa-jaxb-tools/issues/33